### PR TITLE
Final round of accessibility updates

### DIFF
--- a/public/assets/psu.css
+++ b/public/assets/psu.css
@@ -115,7 +115,8 @@ span.component {
 .table > :not(caption) > * > * { padding: 0; }
 
 ul.facet-list { padding-left: 0; }
-ul.facet-list > li { list-style-type: none; }
+ul.facet-list > li,
+.more-facets li { list-style-type: none; }
 
 /* root node color and text decoration (will perma-fix later) */
 .root-node .node-title,

--- a/public/assets/psu.css
+++ b/public/assets/psu.css
@@ -1,5 +1,6 @@
 /* make our color contrasts WCAG AAA-compliant */
-.record-type-badge.digital_object {
+.record-type-badge.digital_object,
+.record-type-badge.resource {
   color: #901824;
   border-color: #901824;
 }
@@ -7,6 +8,7 @@
 /* PSU Theme style alterations work with archivesspace */
 body {
   --bs-border-width: 1px;
+  --bs-border-color: rgb(124, 142, 162);
 }
 
 h1 {

--- a/public/assets/psu.css
+++ b/public/assets/psu.css
@@ -21,6 +21,11 @@ h1 {
   font-size: 1.25rem;
 }
 
+.h4, h4 {
+  font-family: "PT Sans", "Helvetica Neue", helvetica, arial, sans-serif;
+  font-size: 1rem;
+}
+
 span.component {
   font-weight: 400;
 }
@@ -108,6 +113,9 @@ span.component {
 
 /* override PSU theming */
 .table > :not(caption) > * > * { padding: 0; }
+
+ul.facet-list { padding-left: 0; }
+ul.facet-list > li { list-style-type: none; }
 
 /* root node color and text decoration (will perma-fix later) */
 .root-node .node-title,

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,8 +1,8 @@
 # enable/disable Matomo analytics
-AppConfig[:matomo_enabled] = true
+AppConfig[:matomo_enabled] = false
 
 # display announcement
-AppConfig[:display_announcement] = false
+AppConfig[:display_announcement] = true
 
 # branding image and favicon
 AppConfig[:pui_branding_img] = 'assets/pennstate.png'

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -10,7 +10,7 @@ AppConfig[:pui_branding_img_alt_text] = 'Penn State University Libraries'
 AppConfig[:pui_show_favicon] = true
 
 # controller types to hide from simple search
-AppConfig[:hide_from_simple_search] = ['search', 'resources', 'accessions', 'objects', 'subjects', 'agents', 'classifications']
+AppConfig[:hide_from_simple_search] = ['search', 'resources', 'accessions', 'objects', 'subjects', 'agents', 'classifications', 'repositories']
 
 # make sure EAD Location appears in resource records
 Rails.application.config.after_initialize do

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
 	<% end %>
 	<!-- End plugin layout -->
 
-	<main id="maincontent" class="container-fluid mt-2 pt-2 flex-grow-1">
+	<main id="maincontent" class="container-fluid mt-2 p-2 flex-grow-1">
 		<%= flash_messages %>
 		<%= yield %>
 	</main>

--- a/public/views/objects/show.html.erb
+++ b/public/views/objects/show.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <% if @result.instance_of?(ArchivalObject) %>
-      <hr>
+      <hr role="separator">
       <% if AppConfig[:pui_search_collection_from_archival_objects] %>
         <div class="p-2">
           <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result.resource_uri, :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>

--- a/public/views/repositories/_badge.html.erb
+++ b/public/views/repositories/_badge.html.erb
@@ -1,0 +1,35 @@
+<%# the "badges" for resources, records, etc.  Expects one local: type[ of badge]. @sublist_action, @counts, and @result carry through %>
+
+<div class="large-badge align-center <%= type %> border p-2 my-2 mx-2 ml-sm-0 mr-sm-4">
+  <form action="<%= app_prefix(@sublist_action) %><%= type %>s" method="get">
+    <button type="submit" class="btn <%= type %>" <%= @counts[type] == 0 ? 'disabled="disabled"' : '' %>  >
+      <% case type %>
+      <% when 'resource' %>
+        <i class="fa fa-archive fa-4x"></i>
+      <% when 'record' %>
+        <input type="hidden" name="limit" value="archival_object" />
+        <i class="fa fa-files-o fa-4x"></i>
+      <% when 'digital_object' %>
+        <input type="hidden" name="limit" value="digital_object" />
+        <i class="fa fa-file-image-o fa-4x"></i>
+      <% when 'accession' %>
+        <i class="fa fa-file-text-o fa-4x"></i>
+      <% when 'subject' %>
+        <i class="fa fa-tags fa-4x"></i>
+      <% when 'agent' %>
+      <span class="fa-stack fa-2x">
+        <i class="fa fa-institution fa-stack-2x"></i>
+        <i class="fa fa-users fa-stack-1x fa-inverse"></i>
+      </span>
+      <% when 'classification' %>
+        <i class="fa fa-share-alt fa-4x"></i>
+      <% end %>
+      <br />
+      <% if AppConfig[:pui_repos].dig(@result['repo_code'].downcase, :hide, :counts).nil? ?  AppConfig[:pui_hide][:counts] :  AppConfig[:pui_repos][@result['repo_code'].downcase][:hide][:counts] %>
+        <%= t("#{type}._plural") %>
+      <% else %>
+        <%= @counts[type] %> <%= (@counts['type'] != 1 ? t("#{type}._plural") : t("#{type}._singular")) %>
+      <% end %>
+    </button>
+  </form>
+</div>

--- a/public/views/repositories/show.html.erb
+++ b/public/views/repositories/show.html.erb
@@ -6,7 +6,7 @@
   <div id="whats-in-container" class="p-4 my-4">
     <h2 class="text-center text-sm-left"><%= t('repository.what') %> </h2>
     <div>
-      <div class="list-inline d-flex flex-wrap justify-content-center justify-content-sm-start">
+      <div class="list-inline d-flex flex-wrap justify-content-center">
         <% @badges.each do |type| %>
           <%= render partial: 'repositories/badge', locals: {:type => type} %>
         <% end %>

--- a/public/views/repositories/show.html.erb
+++ b/public/views/repositories/show.html.erb
@@ -1,0 +1,31 @@
+<div id="main-content" class="repositories">
+  <div class="abstract">
+    <%= render partial: 'repositories/repository', locals: {:result => @result,  :full => true} %>
+  </div>
+
+  <div id="whats-in-container" class="p-4 my-4">
+    <h2 class="text-center text-sm-left"><%= t('repository.what') %> </h2>
+    <div>
+      <div class="list-inline d-flex flex-wrap justify-content-center justify-content-sm-start">
+        <% @badges.each do |type| %>
+          <%= render partial: 'repositories/badge', locals: {:type => type} %>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+  <%= render partial: 'shared/search', locals: {:search_url => "#{@result['uri']}/search",
+   :title => t('repository._singular'),
+   :limit_options =>  [["#{t('actions.search')} #{t('search-limits.all')}",''],
+            [t('search-limit', :limit => t('search-limits.resources')),'resource'],
+            [t('search-limit', :limit => t('search-limits.digital')),'digital_object']],
+
+   :field_options => [["#{t('search_results.filter.fullrecord')}",''],
+            ["#{t('search_results.filter.title')}",'title'],
+            ["#{t('search_results.filter.creators')}",'creators_text'],
+            ["#{t('search_results.filter.subjects')}",'subjects_text'],
+            ["#{t('search_results.filter.notes')}", 'notes'],
+            ["#{t('search_results.filter.identifier')}", 'identifier'] ],
+   :header_size => '2',
+   :show_header => true } %>
+</div>

--- a/public/views/resources/digitized.html.erb
+++ b/public/views/resources/digitized.html.erb
@@ -23,7 +23,7 @@
       <%= render partial: 'shared/facets' %>
     <% end %>
 
-    <hr>
+    <hr role="separator">
 
     <div class="p-2">
       <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>

--- a/public/views/resources/inventory.html.erb
+++ b/public/views/resources/inventory.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <hr>
+    <hr role="separator">
 
     <% if defined?(@filters) && defined?(@search) %>
       <%= render partial: 'shared/facets' %>

--- a/public/views/resources/show.html.erb
+++ b/public/views/resources/show.html.erb
@@ -28,7 +28,7 @@
       <%= render partial: 'shared/facets' %>
     <% end %>
 
-    <hr>
+    <hr role="separator">
 
     <div class="p-2">
       <%= render partial: 'shared/search_collection_form', :locals => {:resource_uri => @result['uri'], :action_text => "#{t('actions.search_in', :type => t('resource._singular'))}"} %>

--- a/public/views/search/search_results.html.erb
+++ b/public/views/search/search_results.html.erb
@@ -5,54 +5,55 @@
     <% if defined?(@search_title) %>
       <h1><%= @search_title %></h1>
     <% else %>
-      <h1 class="visually-hidden"><%= @page_title %></h1>
+      <% unless @reset %>
+        <h1 class="visually-hidden"><%= @page_title %></h1>
+      <% end %>
     <% end %>
 
-  <% if defined?(@reset) && @reset %>
+    <% if defined?(@reset) && @reset %>
       <%= render partial: 'shared/search', locals: {:search_url => @base_search,
                                                     :title => t('archive._plural'),
                                                     :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],
-                                                                       [t('search-limit', :limit => t('search-limits.resources')),'resource'],
-                                                                       [t('search-limit', :limit => t('search-limits.digital')),'digital_object']],
+                                                                      [t('search-limit', :limit => t('search-limits.resources')),'resource'],
+                                                                      [t('search-limit', :limit => t('search-limits.digital')),'digital_object']],
                                                     :field_options => [["#{t('search_results.filter.fullrecord')}",''],
-                                                                       ["#{t('search_results.filter.title')}",'title'],
-                                                                       ["#{t('search_results.filter.creators')}",'creators_text'],
-                                                                       ["#{t('search_results.filter.subjects')}",'subjects_text'],
-                                                                       ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                       ["#{t('search_results.filter.identifier')}", 'identifier'] ],
-                                                    :header_size => '2',
+                                                                      ["#{t('search_results.filter.title')}",'title'],
+                                                                      ["#{t('search_results.filter.creators')}",'creators_text'],
+                                                                      ["#{t('search_results.filter.subjects')}",'subjects_text'],
+                                                                      ["#{t('search_results.filter.notes')}", 'notes'],
+                                                                      ["#{t('search_results.filter.identifier')}", 'identifier'] ],
+                                                    :header_size => '1',
                                                     :show_header => true } %>
-  <% else %>
+    <% else %>
 
-  <% unless defined?(@no_statement) %>
-    <div class="searchstatement bg-light px-3 py-2 shadow-sm border mb-3">
-      <div class="btn btn-group pull-right">
-        <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-primary" %>
-        <button class="btn btn-sm btn-primary" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
-      </div>
-
-      <% if defined?(@search) %>
-        <%= @search[:search_statement].html_safe %>
+      <% unless defined?(@no_statement) %>
+        <div class="row searchstatement bg-light px-3 py-2 shadow-sm border mb-3">
+          <div class="col">
+            <% if defined?(@search) %>
+              <%= @search[:search_statement].html_safe %>
+            <% end %>            
+          </div>
+          <div class="btn btn-group col-sm-auto">
+            <%= link_to I18n.t('actions.new_search'), (defined?(@new_search) ? @new_search : root_path), :class => "btn btn-sm btn-primary" %>
+            <button class="btn btn-sm btn-primary" id="toggleRefineSearch" aria-expanded="false" aria-controls="refineSearchPanel"><%= I18n.t('actions.refine_search') %></button>
+          </div>
+          <div id="refineSearchPanel" class="container refinesearch" aria-hidden="true" style="display:none;">
+            <%= render partial: 'shared/search', locals: {:search_url => @base_search,
+                                                          :title => t('archive._plural'),
+                                                          :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],
+                                                                            [t('search-limit', :limit => t('search-limits.resources')),'resource'],
+                                                                            [t('search-limit', :limit => t('search-limits.digital')),'digital_object']],
+                                                          :field_options => [["#{t('search_results.filter.fullrecord')}",''],
+                                                                            ["#{t('search_results.filter.title')}",'title'],
+                                                                            ["#{t('search_results.filter.creators')}",'creators_text'],
+                                                                            ["#{t('search_results.filter.subjects')}",'subjects_text'],
+                                                                            ["#{t('search_results.filter.notes')}", 'notes'],
+                                                                            ["#{t('search_results.filter.identifier')}", 'identifier'] ],
+                                                          :show_header => false } %>
+          </div>
+        </div>
       <% end %>
-
-      <div id="refineSearchPanel" class="container refinesearch" aria-hidden="true" style="display:none;">
-        <%= render partial: 'shared/search', locals: {:search_url => @base_search,
-                                                      :title => t('archive._plural'),
-                                                      :limit_options => [["#{t('actions.search')} #{t('search-limits.all')}",''],
-                                                                         [t('search-limit', :limit => t('search-limits.resources')),'resource'],
-                                                                         [t('search-limit', :limit => t('search-limits.digital')),'digital_object']],
-                                                      :field_options => [["#{t('search_results.filter.fullrecord')}",''],
-                                                                         ["#{t('search_results.filter.title')}",'title'],
-                                                                         ["#{t('search_results.filter.creators')}",'creators_text'],
-                                                                         ["#{t('search_results.filter.subjects')}",'subjects_text'],
-                                                                         ["#{t('search_results.filter.notes')}", 'notes'],
-                                                                         ["#{t('search_results.filter.identifier')}", 'identifier'] ],
-                                                      :show_header => false } %>
-      </div>
-    </div>
-  <% end %>
-
-  <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/public/views/shared/_facet_description.html.erb
+++ b/public/views/shared/_facet_description.html.erb
@@ -1,0 +1,8 @@
+<li>
+  <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(facet.key)}") %>"
+    rel="nofollow"
+    title="<%= t('search_results.filter_by')%> '<%= t("search_results.filter.#{type}") %>' of '<%= facet.label %>'">
+    <%= facet.label %>
+  </a>
+  <span class="badge badge-pill badge-dark"><%= facet.count %></span>
+</li>

--- a/public/views/shared/_facet_description.html.erb
+++ b/public/views/shared/_facet_description.html.erb
@@ -1,7 +1,7 @@
 <li>
   <a href="<%= app_prefix("#{@page_search}&filter_fields[]=#{type}&filter_values[]=#{CGI.escape(facet.key)}") %>"
     rel="nofollow"
-    title="<%= t('search_results.filter_by')%> '<%= t("search_results.filter.#{type}") %>' of '<%= facet.label %>'">
+    aria-label="<%= t('search_results.filter_by') %> '<%= t("search_results.filter.#{type}") %>' of '<%= facet.label %>' (<%= facet.count %> results)">
     <%= facet.label %>
   </a>
   <span class="badge badge-pill badge-dark"><%= facet.count %></span>

--- a/public/views/shared/_only_facets.html.erb
+++ b/public/views/shared/_only_facets.html.erb
@@ -34,7 +34,7 @@
             <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
           <% end %>
           <div class="more-facets">
-            <button type="button" class="more-facets__more mb-1 btn btn-sm">
+            <button type="button" class="more-facets__more my-1 btn btn-sm">
               <%= t('search_results.more_facets') %> <i class="fa fa-chevron-down"></i>
             </button>
             <div class="more-facets__facets">
@@ -42,7 +42,7 @@
                 <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
               <% end %>
             </div>
-            <button type="button" class="more-facets__less mb-1 btn btn-sm">
+            <button type="button" class="more-facets__less my-1 btn btn-sm">
               <%= t('search_results.fewer_facets') %> <i class="fa fa-chevron-up"></i>
             </button>
           </div>

--- a/public/views/shared/_only_facets.html.erb
+++ b/public/views/shared/_only_facets.html.erb
@@ -1,0 +1,54 @@
+<% unless @facets.blank? %>
+<h3><%= t('search_results.filter.add')%>: </h3>
+<section id="facets">
+
+  <%
+    preferred_facet_order = %w(repository primary_type agents subjects langcode)
+    ordered_facet_types = @facets.keys.sort{|a,b|
+      if preferred_facet_order.include?(a) && preferred_facet_order.include?(b)
+        preferred_facet_order.index(a) <=> preferred_facet_order.index(b)
+      elsif preferred_facet_order.include?(a)
+        -1
+      elsif preferred_facet_order.include?(b)
+        1
+      else
+        0
+      end
+    }
+  %>
+
+  <% ordered_facet_types.each do |type| %>
+    <%
+      facet_group = @facets.fetch(type, false)
+      max_facets_on_load = 5
+    %>
+    <div id="<%= t("search_results.filter.#{type}").downcase %>-facet">
+      <h4 class='mb-2 mt-3'><%= t("search_results.filter.#{type}") %></h4>
+      <ul class="facet-list">
+        <% if facet_group.length <= max_facets_on_load %>
+          <% facet_group.each do |facet| %>
+            <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+          <% end %>
+        <% else %>
+          <% facet_group.slice(0, max_facets_on_load).each do |facet| %>
+            <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+          <% end %>
+          <div class="more-facets">
+            <button type="button" class="more-facets__more mb-1 btn btn-sm">
+              <%= t('search_results.more_facets') %> <i class="fa fa-chevron-down"></i>
+            </button>
+            <div class="more-facets__facets">
+              <% facet_group.slice(max_facets_on_load, facet_group.length - 1).each do |facet| %>
+                <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+              <% end %>
+            </div>
+            <button type="button" class="more-facets__less mb-1 btn btn-sm">
+              <%= t('search_results.fewer_facets') %> <i class="fa fa-chevron-up"></i>
+            </button>
+          </div>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</section>
+<% end %>

--- a/public/views/shared/_simple_search.html.erb
+++ b/public/views/shared/_simple_search.html.erb
@@ -1,4 +1,4 @@
-<section id="simple_search" class="d-flex flex-row row pt-2 pb-1 align-items-center bg-light">
+<section id="simple_search" class="d-flex flex-row row pt-2 pb-1 align-items-center bg-light" aria-label="search the archives">
   <div class="col-md-8">
     <% @search = Search.new unless defined?(@search) %>
     <%= form_tag(app_prefix("#{search_url}"), method: 'get', :id => 'simple_search') do %>


### PR DESCRIPTION
There are two issues we have left unaddressed:

* The datepicker is still buggy from a screen-reader perspective. LST says there are no good options for datepickers at the moment, so we'll leave it be for now and keep an eye out for any libraries that don't cause screen reader problems.
* We will look into better options for labeling the advanced search form -- ideally the form labels would be headings instead of labels, but I'm not sure if every advanced search form label should be an `<h4>` as it would be on the repository pages.